### PR TITLE
Styling tweaks for consistency, building with recent PlatformIO

### DIFF
--- a/firmware/open_evse/J1772EvseController.cpp
+++ b/firmware/open_evse/J1772EvseController.cpp
@@ -1909,14 +1909,13 @@ int J1772EVSEController::HeartbeatSupervision(uint16_t interval, uint8_t amps)
   if (eeprom_read_byte((uint8_t*)EOFS_HEARTBEAT_SUPERVISION_CURRENT) != m_IFallback){ //only write EEPROM if it is needful!
     eeprom_write_byte((uint8_t*)EOFS_HEARTBEAT_SUPERVISION_CURRENT, amps);
   }
+  return 0; // No error codes yet
 }
 
 int J1772EVSEController::HsPulse()
 {
   int rc = 1;
-  if (m_HsTriggered = HS_MISSEDPULSE_NOACK) { //We were in a state of missed pulse therefore we need to restore the current capacity since we now see a Pulse
-	rc = 1; //We have been triggered but have not been acknowledged responce with NK
-	}
+  if ((m_HsTriggered = HS_MISSEDPULSE_NOACK)) { //We were in a state of missed pulse therefore we need to restore the current capacity since we now see a Pulse
   else { // If we have been triggered it has been dealt with (m_HsTriggered = HS_MISSEDPULSE or 0)
     rc = 0; 
   }
@@ -1948,10 +1947,7 @@ int J1772EVSEController::HsExpirationCheck()
 {
   unsigned long sinceLastPulse = (millis() - m_HsLastPulse);
   int rc=1;
-  if (m_HsInterval != 0){ //HEARTBEAT_SUPERVISION is currently active
-    if(m_HsTriggered = HS_MISSEDPULSE_NOACK) { //There has been a pulse miss that has not been acknowledged
-      if(!(m_IFallback > GetCurrentCapacity())){ //We are still in HEARTBEAT_SUPERVISION ampacity limiting but the current capacity is not OK
-	    rc=SetCurrentCapacity(m_IFallback,0,0);  //Drop the current, but do not update the display and do not write it to EEPROM        
+    if((m_HsTriggered = HS_MISSEDPULSE_NOACK)) { //There has been a pulse miss that has not been acknowledged
 	  }
     }
     else if (sinceLastPulse > m_HsInterval){//Whups, we didn't get a heartbeat within the specified time interval, and HS is in active state

--- a/firmware/open_evse/J1772EvseController.h
+++ b/firmware/open_evse/J1772EvseController.h
@@ -101,11 +101,11 @@ typedef uint8_t (*EvseStateTransitionReqFunc)(uint8_t prevPilotState,uint8_t cur
 #define ECVF_DEFAULT            ECVF_SESSION_ENDED
 #endif
 
-#define HS_INTERVAL_DEFAULT     0x0000	//By default, on an unformatted EEPROM, Heartbeat Supervision is not activated
-#define HS_IFALLBACK_DEFAULT	0x00    //By default, on an unformatted EEPROM, HS fallback current is 0 Amperes 
+#define HS_INTERVAL_DEFAULT     0x0000  //By default, on an unformatted EEPROM, Heartbeat Supervision is not activated
+#define HS_IFALLBACK_DEFAULT    0x00    //By default, on an unformatted EEPROM, HS fallback current is 0 Amperes 
 #define HS_ACK_COOKIE           0XA5    //ACK will not work unless it contin this cookie
-#define HS_MISSEDPULSE_NOACK    0x02	//HEARTBEAT_SUPERVISION missed a pulse and this has not been acknowleged
-#define HS_MISSEDPULSE		    0x01	//HEARTBEAT_SUPERVISION missed a pulse and this is the semi-permanent record flag
+#define HS_MISSEDPULSE_NOACK    0x02    //HEARTBEAT_SUPERVISION missed a pulse and this has not been acknowleged
+#define HS_MISSEDPULSE          0x01    //HEARTBEAT_SUPERVISION missed a pulse and this is the semi-permanent record flag
 
 
 class J1772EVSEController {
@@ -246,10 +246,10 @@ class J1772EVSEController {
 #endif // VOLTMETER
 
 #ifdef HEARTBEAT_SUPERVISION
-  uint16_t 	m_HsInterval;  		// Number of seconds HS will wait for a heartbeat before reducing ampacity to m_IFallback.  If 0 disable.
-  uint8_t  	m_IFallback;   		// HEARTBEAT_SUPERVISION fallback current in Amperes.  
-  uint8_t 	m_HsTriggered;		// Will be 0 if HEARTBEAT_SUPERVISION has never had a missed pulse
-  unsigned long m_HsLastPulse;	// The last time we saw a HS pulse or the last time m_HsInterval elpased without seeing one.  Set to 0 if HEARTBEAT_SUPERVISION triggered                                   
+  uint16_t     m_HsInterval;          // Number of seconds HS will wait for a heartbeat before reducing ampacity to m_IFallback.  If 0 disable.
+  uint8_t      m_IFallback;           // HEARTBEAT_SUPERVISION fallback current in Amperes.  
+  uint8_t     m_HsTriggered;        // Will be 0 if HEARTBEAT_SUPERVISION has never had a missed pulse
+  unsigned long m_HsLastPulse;    // The last time we saw a HS pulse or the last time m_HsInterval elpased without seeing one.  Set to 0 if HEARTBEAT_SUPERVISION triggered                                   
 #endif //HEARTBEAT_SUPERVISION
 
 public:
@@ -387,7 +387,7 @@ public:
   void EnableTempChk(uint8_t tf);
 #endif //TEMPERATURE_MONITORING
 
-#ifdef	HEARTBEAT_SUPERVISION
+#ifdef HEARTBEAT_SUPERVISION
 int HeartbeatSupervision(uint16_t interval, uint8_t amps);
 int HsPulse();
 int HsRestoreAmpacity();

--- a/firmware/open_evse/rapi_proc.cpp
+++ b/firmware/open_evse/rapi_proc.cpp
@@ -490,7 +490,7 @@ int EvseRapiProcessor::processCmd()
     case 'Y': // HEARTBEAT SUPERVISION
       if (tokenCnt == 1)  { //This is a heartbeat
         rc = g_EvseController.HsPulse(); //pet the dog
-        }
+      }
       else if (tokenCnt == 3) { //This is a full HEARTBEAT_SUPERVISION setpoint command with both parameters
         u2.u16 = (uint16_t)dtou32(tokens[2]);	// HS Interval in seconds.  0 = disabled
         u1.u8 = (uint8_t)dtou32(tokens[1]);	// HS fallback current, in amperes  
@@ -499,17 +499,17 @@ int EvseRapiProcessor::processCmd()
         }
         else { // This is the case where we are disabling HEARTBEAT_SUPERVISION  
           rc = (g_EvseController.HsDeactivate() || g_EvseController.HsRestoreAmpacity());
-        }		
+        }
       }
-  	  else if (tokenCnt == 2) { //This is a command to ack a hearbtbeat supervison miss
+      else if (tokenCnt == 2) { //This is a command to ack a hearbtbeat supervison miss
         u1.u8 = (uint8_t)dtou32(tokens[1]); //Magic cookie
-  	    g_EvseController.HsAckMissedPulse(u1.u8);
-  	  }
+        g_EvseController.HsAckMissedPulse(u1.u8);
+      }
       else { //Invalid number of tokens, return 1
         rc = 1; //Invalid number of tokens
       }
       sprintf(buffer,"%d %d %d", g_EvseController.GetHearbeatInterval(), g_EvseController.GetHearbeatCurrent(), g_EvseController.GetHearbeatCurrent());
-	  bufCnt = 1; 
+      bufCnt = 1; 
       break;
 #endif //HEARTBEAT_SUPERVISION
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -8,7 +8,7 @@
 ; http://docs.platformio.org/en/stable/projectconf.html
 
 [platformio]
-env_default = openevse
+default_envs = openevse
 src_dir = firmware/open_evse
 
 [common]
@@ -16,7 +16,7 @@ lib_deps =
 
 [env:openevse]
 platform = atmelavr
-board = OpenEVSE
+board = openevse
 framework = arduino
 lib_deps = ${common.lib_deps}
 upload_protocol = usbasp


### PR DESCRIPTION
These changes are all cosmetic - mostly replacing tabs that represent groups of four spaces with spaces because the project already has other tabs that are supposed to be eight spaces wide and it made the indentation confusing.
The only meaningful change is in the PlatformIO configuration, which the project probably should have updated sooner.
Nice work!